### PR TITLE
Remove obsolete commented out code

### DIFF
--- a/lib/Net/Works/Address.pm
+++ b/lib/Net/Works/Address.pm
@@ -21,11 +21,6 @@ use Socket 1.99 qw( AF_INET AF_INET6 inet_pton inet_ntop );
 
 use integer;
 
-# Using this currently breaks overloading - see
-# https://rt.cpan.org/Ticket/Display.html?id=50938
-#
-#use namespace::autoclean;
-
 use overload (
     q{""} => '_overloaded_as_string',
     '<=>' => '_compare_overload',

--- a/lib/Net/Works/Network.pm
+++ b/lib/Net/Works/Network.pm
@@ -19,11 +19,6 @@ use Socket 1.99 qw( inet_pton AF_INET AF_INET6 );
 
 use integer;
 
-# Using this currently breaks overloading - see
-# https://rt.cpan.org/Ticket/Display.html?id=50938
-#
-#use namespace::autoclean;
-
 use overload (
     q{""} => '_overloaded_as_string',
     '<=>' => '_compare_overload',


### PR DESCRIPTION
The mentioned bug is fixed as namespace::clean is included higher.

Submitted in participation with CPAN PRC CV-Library