### PR TITLE
Fix handling of inheritance for next/previous_ip

### DIFF
--- a/lib/Net/Works/Address.pm
+++ b/lib/Net/Works/Address.pm
@@ -117,7 +117,7 @@ sub as_ipv4_string {
         'Cannot represent IP address larger than 2**32-1 as an IPv4 string'
         if $self->as_integer() >= 2**32;
 
-    return __PACKAGE__->new_from_integer(
+    return $self->new_from_integer(
         integer => $self->as_integer(),
         version => 4,
     )->as_string();
@@ -146,7 +146,7 @@ sub next_ip {
     confess "$self is the last address in its range"
         if $self->as_integer() == $self->_max;
 
-    return __PACKAGE__->new_from_integer(
+    return $self->new_from_integer(
         integer => $self->as_integer() + 1,
         version => $self->version(),
     );
@@ -158,7 +158,7 @@ sub previous_ip {
     confess "$self is the first address in its range"
         if $self->as_integer() == 0;
 
-    return __PACKAGE__->new_from_integer(
+    return $self->new_from_integer(
         integer => $self->as_integer() - 1,
         version => $self->version(),
     );

--- a/t/Address.t
+++ b/t/Address.t
@@ -10,8 +10,15 @@ use Net::Works::Address;
 
 {
     my $ip = Net::Works::Address->new_from_string( string => '1.2.3.4' );
+<<<<<<< Updated upstream
     is( $ip->as_string(), '1.2.3.4',
         '->as_string returns string passed to constructor' );
+=======
+    is(
+        $ip->as_string(), '1.2.3.4',
+        '->as_string returns string passed to constructor'
+    );
+>>>>>>> Stashed changes
 
     my $next = $ip->next_ip();
     isa_ok( $next, 'Net::Works::Address', 'return value of ->next_ip' );
@@ -21,8 +28,15 @@ use Net::Works::Address;
     my $prev = $ip->previous_ip();
     isa_ok( $prev, 'Net::Works::Address', 'return value of ->previous_ip' );
 
+<<<<<<< Updated upstream
     is( $prev->as_string(), '1.2.3.3',
         'previous ip before 1.2.3.4 is 1.2.3.3' );
+=======
+    is(
+        $prev->as_string(), '1.2.3.3',
+        'previous ip before 1.2.3.4 is 1.2.3.3'
+    );
+>>>>>>> Stashed changes
 
     is( "$ip", '1.2.3.4', 'stringification of address object works' );
 
@@ -37,8 +51,15 @@ use Net::Works::Address;
     cmp_ok( $ip, '==', $same_ip,
         'numeric overloading (==) on address objects works' );
 
+<<<<<<< Updated upstream
     is( $ip <=> $same_ip,
         0, 'comparison overloading (==) on address objects works' );
+=======
+    is(
+        $ip <=> $same_ip,
+        0, 'comparison overloading (==) on address objects works'
+    );
+>>>>>>> Stashed changes
 }
 
 {
@@ -62,22 +83,42 @@ use Net::Works::Address;
         abcd::1000
     );
 
+<<<<<<< Updated upstream
     is_deeply( [ map { $_->as_string() } sort { $a <=> $b } @ips ],
         \@sorted, 'address objects sort numerically' );
 
     is_deeply( [ map { $_->as_string() } sort { $a cmp $b } @ips ],
         \@sorted, 'address objects sort alphabetically' );
+=======
+    is_deeply(
+        [ map { $_->as_string() } sort { $a <=> $b } @ips ],
+        \@sorted, 'address objects sort numerically'
+    );
+
+    is_deeply(
+        [ map { $_->as_string() } sort { $a cmp $b } @ips ],
+        \@sorted, 'address objects sort alphabetically'
+    );
+>>>>>>> Stashed changes
 }
 
 {
     my $ip = Net::Works::Address->new_from_string( string => '192.168.0.255' )
         ->next_ip();
+<<<<<<< Updated upstream
     is( $ip->as_string(), '192.168.1.0',
         '->next_ip wraps to the next ip address' );
+=======
+    is(
+        $ip->as_string(), '192.168.1.0',
+        '->next_ip wraps to the next ip address'
+    );
+>>>>>>> Stashed changes
 }
 
 {
     my $ip = Net::Works::Address->new_from_string( string => 'ffff::a:1234' );
+<<<<<<< Updated upstream
     is( $ip->as_string(), 'ffff::a:1234',
         '->as_string returns string passed to constructor' );
 
@@ -88,13 +129,38 @@ use Net::Works::Address;
     my $next = $ip->next_ip();
     is( $next->as_string(), 'ffff::a:1235',
         'next ip after ffff::a:1234 is ffff::a:1235' );
+=======
+    is(
+        $ip->as_string(), 'ffff::a:1234',
+        '->as_string returns string passed to constructor'
+    );
+
+    my $prev = $ip->previous_ip();
+    is(
+        $prev->as_string(), 'ffff::a:1233',
+        'previous ip before ffff::a:1234 is ffff::a:1233'
+    );
+
+    my $next = $ip->next_ip();
+    is(
+        $next->as_string(), 'ffff::a:1235',
+        'next ip after ffff::a:1234 is ffff::a:1235'
+    );
+>>>>>>> Stashed changes
 }
 
 {
     my $ip = Net::Works::Address->new_from_string(
         string => 'ffff::0000:000a:1234' );
+<<<<<<< Updated upstream
     is( $ip->as_string(), 'ffff::a:1234',
         '->as_string returns compact form of IPv6' );
+=======
+    is(
+        $ip->as_string(), 'ffff::a:1234',
+        '->as_string returns compact form of IPv6'
+    );
+>>>>>>> Stashed changes
 }
 
 {
@@ -142,8 +208,15 @@ use Net::Works::Address;
         version => 4,
     );
 
+<<<<<<< Updated upstream
     is( $ip->as_string(), '255.255.255.255',
         'new_from_integer(2**32 - 1), IPv4' );
+=======
+    is(
+        $ip->as_string(), '255.255.255.255',
+        'new_from_integer(2**32 - 1), IPv4'
+    );
+>>>>>>> Stashed changes
 
     is( $ip->as_integer(), 2**32 - 1, 'as_integer returns 2**32 - 1' );
 
@@ -165,8 +238,15 @@ use Net::Works::Address;
         version => 6,
     );
 
+<<<<<<< Updated upstream
     is( $ip->as_string(), '::255.255.255.255',
         'new_from_integer(2**32 - 1), IPv6' );
+=======
+    is(
+        $ip->as_string(), '::255.255.255.255',
+        'new_from_integer(2**32 - 1), IPv6'
+    );
+>>>>>>> Stashed changes
 
     is( $ip->as_bit_string(),
         ( '0' x 96 ) . ( '1' x 32 ),
@@ -190,8 +270,15 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
             'new_from_integer(2**128 - 1), IPv6'
         );
 
+<<<<<<< Updated upstream
         is( $ip->as_integer(), $max_128,
             'as_integer returns 2**128 - 1, IPv6' );
+=======
+        is(
+            $ip->as_integer(), $max_128,
+            'as_integer returns 2**128 - 1, IPv6'
+        );
+>>>>>>> Stashed changes
 
         is( $ip->as_bit_string(), '1' x 128, 'as_bit_string returns 1x128' );
 
@@ -233,8 +320,15 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
             version => 6,
         );
 
+<<<<<<< Updated upstream
         is( $ip->as_ipv4_string(), $tests{$raw},
             "$raw as IPv4 is $tests{$raw}" );
+=======
+        is(
+            $ip->as_ipv4_string(), $tests{$raw},
+            "$raw as IPv4 is $tests{$raw}"
+        );
+>>>>>>> Stashed changes
     }
 }
 
@@ -261,12 +355,25 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
     my $ip = Foo->new_from_string( string => '1.2.3.4' );
 
     my $next = $ip->next_ip();
+<<<<<<< Updated upstream
     isa_ok( $next, 'Foo',
         'return object of child class for value of ->next_ip' );
 
     my $prev = $ip->previous_ip();
     isa_ok( $prev, 'Foo',
         'return object of child class for value of ->previous_ip' );
+=======
+    isa_ok(
+        $next, 'Foo',
+        'return object of child class for value of ->next_ip'
+    );
+
+    my $prev = $ip->previous_ip();
+    isa_ok(
+        $prev, 'Foo',
+        'return object of child class for value of ->previous_ip'
+    );
+>>>>>>> Stashed changes
 
     my %tests = (
         '::0'         => '0.0.0.0',
@@ -281,8 +388,15 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
             version => 6,
         );
 
+<<<<<<< Updated upstream
         is( $foo->as_ipv4_string(),
             $tests{$raw}, "$raw as IPv4 is $tests{$raw}" );
+=======
+        is(
+            $foo->as_ipv4_string(),
+            $tests{$raw}, "$raw as IPv4 is $tests{$raw}"
+        );
+>>>>>>> Stashed changes
     }
 }
 

--- a/t/Address.t
+++ b/t/Address.t
@@ -360,4 +360,56 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
     );
 }
 
+{
+    {
+        package Foo;
+        use base qw(Net::Works::Address);
+    }
+
+    my $ip = Foo->new_from_string( string => '1.2.3.4' );
+
+    my $next = $ip->next_ip();
+    isa_ok(
+        $next,
+        'Foo',
+        'return object of child class for value of ->next_ip'
+    );
+
+    my $prev = $ip->previous_ip();
+    isa_ok(
+        $prev,
+        'Foo',
+        'return object of child class for value of ->previous_ip'
+    );
+
+    my %tests = (
+        '::0'         => '0.0.0.0',
+        '::2'         => '0.0.0.2',
+        '::ffff'      => '0.0.255.255',
+        '::ffff:ffff' => '255.255.255.255',
+    );
+
+    for my $raw ( sort keys %tests ) {
+        my $ip = Foo->new_from_string(
+            string  => $raw,
+            version => 6,
+        );
+
+        is(
+            $ip->as_ipv4_string(),
+            $tests{$raw},
+            "$raw as IPv4 is $tests{$raw}"
+        );
+    }
+
+
+#    my $ipv4 = $ip->as_ipv4_string();
+#    isa_ok(
+#        $ipv4,
+#        'Foo',
+#        'return object of child class for value of ->as_ipv4_string'
+#    );
+
+}
+
 done_testing();

--- a/t/Address.t
+++ b/t/Address.t
@@ -10,66 +10,35 @@ use Net::Works::Address;
 
 {
     my $ip = Net::Works::Address->new_from_string( string => '1.2.3.4' );
-    is(
-        $ip->as_string(),
-        '1.2.3.4',
-        '->as_string returns string passed to constructor'
-    );
+    is( $ip->as_string(), '1.2.3.4',
+        '->as_string returns string passed to constructor' );
 
     my $next = $ip->next_ip();
-    isa_ok(
-        $next,
-        'Net::Works::Address',
-        'return value of ->next_ip'
-    );
+    isa_ok( $next, 'Net::Works::Address', 'return value of ->next_ip' );
 
-    is(
-        $next->as_string(),
-        '1.2.3.5',
-        'next ip after 1.2.3.4 is 1.2.3.5'
-    );
+    is( $next->as_string(), '1.2.3.5', 'next ip after 1.2.3.4 is 1.2.3.5' );
 
     my $prev = $ip->previous_ip();
-    isa_ok(
-        $prev,
-        'Net::Works::Address',
-        'return value of ->previous_ip'
-    );
+    isa_ok( $prev, 'Net::Works::Address', 'return value of ->previous_ip' );
 
-    is(
-        $prev->as_string(),
-        '1.2.3.3',
-        'previous ip before 1.2.3.4 is 1.2.3.3'
-    );
+    is( $prev->as_string(), '1.2.3.3',
+        'previous ip before 1.2.3.4 is 1.2.3.3' );
 
-    is(
-        "$ip",
-        '1.2.3.4',
-        'stringification of address object works'
-    );
+    is( "$ip", '1.2.3.4', 'stringification of address object works' );
 
-    cmp_ok(
-        $ip, '<', $next,
-        'numeric overloading (<) on address objects works'
-    );
+    cmp_ok( $ip, '<', $next,
+        'numeric overloading (<) on address objects works' );
 
-    cmp_ok(
-        $next, '>', $ip,
-        'numeric overloading (>) on address objects works'
-    );
+    cmp_ok( $next, '>', $ip,
+        'numeric overloading (>) on address objects works' );
 
     my $same_ip = Net::Works::Address->new_from_string( string => '1.2.3.4' );
 
-    cmp_ok(
-        $ip, '==', $same_ip,
-        'numeric overloading (==) on address objects works'
-    );
+    cmp_ok( $ip, '==', $same_ip,
+        'numeric overloading (==) on address objects works' );
 
-    is(
-        $ip <=> $same_ip,
-        0,
-        'comparison overloading (==) on address objects works'
-    );
+    is( $ip <=> $same_ip,
+        0, 'comparison overloading (==) on address objects works' );
 }
 
 {
@@ -93,65 +62,45 @@ use Net::Works::Address;
         abcd::1000
     );
 
-    is_deeply(
-        [ map { $_->as_string() } sort { $a <=> $b } @ips ],
-        \@sorted,
-        'address objects sort numerically'
-    );
+    is_deeply( [ map { $_->as_string() } sort { $a <=> $b } @ips ],
+        \@sorted, 'address objects sort numerically' );
 
-    is_deeply(
-        [ map { $_->as_string() } sort { $a cmp $b } @ips ],
-        \@sorted,
-        'address objects sort alphabetically'
-    );
+    is_deeply( [ map { $_->as_string() } sort { $a cmp $b } @ips ],
+        \@sorted, 'address objects sort alphabetically' );
 }
 
 {
     my $ip = Net::Works::Address->new_from_string( string => '192.168.0.255' )
         ->next_ip();
-    is(
-        $ip->as_string(),
-        '192.168.1.0',
-        '->next_ip wraps to the next ip address'
-    );
+    is( $ip->as_string(), '192.168.1.0',
+        '->next_ip wraps to the next ip address' );
 }
 
 {
     my $ip = Net::Works::Address->new_from_string( string => 'ffff::a:1234' );
-    is(
-        $ip->as_string(),
-        'ffff::a:1234',
-        '->as_string returns string passed to constructor'
-    );
+    is( $ip->as_string(), 'ffff::a:1234',
+        '->as_string returns string passed to constructor' );
 
     my $prev = $ip->previous_ip();
-    is(
-        $prev->as_string(),
-        'ffff::a:1233',
-        'previous ip before ffff::a:1234 is ffff::a:1233'
-    );
+    is( $prev->as_string(), 'ffff::a:1233',
+        'previous ip before ffff::a:1234 is ffff::a:1233' );
 
     my $next = $ip->next_ip();
-    is(
-        $next->as_string(),
-        'ffff::a:1235',
-        'next ip after ffff::a:1234 is ffff::a:1235'
-    );
+    is( $next->as_string(), 'ffff::a:1235',
+        'next ip after ffff::a:1234 is ffff::a:1235' );
 }
 
 {
     my $ip = Net::Works::Address->new_from_string(
         string => 'ffff::0000:000a:1234' );
-    is(
-        $ip->as_string(),
-        'ffff::a:1234',
-        '->as_string returns compact form of IPv6'
-    );
+    is( $ip->as_string(), 'ffff::a:1234',
+        '->as_string returns compact form of IPv6' );
 }
 
 {
     for my $address (
-        qw( 255.255.255.255 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff )) {
+        qw( 255.255.255.255 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ))
+    {
 
         my $ip = Net::Works::Address->new_from_string( string => $address );
 
@@ -182,92 +131,49 @@ use Net::Works::Address;
         version => 4,
     );
 
-    is(
-        $ip->as_string(),
-        '0.0.0.0',
-        'new_from_integer(0), IPv4'
-    );
+    is( $ip->as_string(), '0.0.0.0', 'new_from_integer(0), IPv4' );
 
-    is(
-        $ip->as_integer(),
-        0,
-        'as_integer returns 0'
-    );
+    is( $ip->as_integer(), 0, 'as_integer returns 0' );
 
-    is(
-        $ip->as_bit_string(),
-        '0' x 32,
-        'as_bit_string returns 0x32'
-    );
+    is( $ip->as_bit_string(), '0' x 32, 'as_bit_string returns 0x32' );
 
     $ip = Net::Works::Address->new_from_integer(
         integer => 2**32 - 1,
         version => 4,
     );
 
-    is(
-        $ip->as_string(),
-        '255.255.255.255',
-        'new_from_integer(2**32 - 1), IPv4'
-    );
+    is( $ip->as_string(), '255.255.255.255',
+        'new_from_integer(2**32 - 1), IPv4' );
 
-    is(
-        $ip->as_integer(),
-        2**32 - 1,
-        'as_integer returns 2**32 - 1'
-    );
+    is( $ip->as_integer(), 2**32 - 1, 'as_integer returns 2**32 - 1' );
 
-    is(
-        $ip->as_bit_string(),
-        '1' x 32,
-        'as_bit_string returns 1x32'
-    );
+    is( $ip->as_bit_string(), '1' x 32, 'as_bit_string returns 1x32' );
 
     $ip = Net::Works::Address->new_from_integer(
         integer => 0,
         version => 6,
     );
 
-    is(
-        $ip->as_string(),
-        '::0',
-        'new_from_integer(0), IPv6'
-    );
+    is( $ip->as_string(), '::0', 'new_from_integer(0), IPv6' );
 
-    is(
-        $ip->as_integer(),
-        0,
-        'as_integer returns 0, IPv6'
-    );
+    is( $ip->as_integer(), 0, 'as_integer returns 0, IPv6' );
 
-    is(
-        $ip->as_bit_string(),
-        '0' x 128,
-        'as_bit_string returns 0x128'
-    );
+    is( $ip->as_bit_string(), '0' x 128, 'as_bit_string returns 0x128' );
 
     $ip = Net::Works::Address->new_from_integer(
         integer => 2**32 - 1,
         version => 6,
     );
 
-    is(
-        $ip->as_string(),
-        '::255.255.255.255',
-        'new_from_integer(2**32 - 1), IPv6'
-    );
+    is( $ip->as_string(), '::255.255.255.255',
+        'new_from_integer(2**32 - 1), IPv6' );
 
-    is(
-        $ip->as_bit_string(),
+    is( $ip->as_bit_string(),
         ( '0' x 96 ) . ( '1' x 32 ),
         'as_bit_string returns 0x96 . 1x32'
     );
 
-    is(
-        $ip->as_integer(),
-        2**32 - 1,
-        'as_integer returns 2**32 - 1, IPv6'
-    );
+    is( $ip->as_integer(), 2**32 - 1, 'as_integer returns 2**32 - 1, IPv6' );
 }
 
 for my $one ( uint128(1), Math::BigInt->bone() ) {
@@ -279,34 +185,22 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
             version => 6,
         );
 
-        is(
-            $ip->as_string(),
+        is( $ip->as_string(),
             'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
             'new_from_integer(2**128 - 1), IPv6'
         );
 
-        is(
-            $ip->as_integer(),
-            $max_128,
-            'as_integer returns 2**128 - 1, IPv6'
-        );
+        is( $ip->as_integer(), $max_128,
+            'as_integer returns 2**128 - 1, IPv6' );
 
-        is(
-            $ip->as_bit_string(),
-            '1' x 128,
-            'as_bit_string returns 1x128'
-        );
+        is( $ip->as_bit_string(), '1' x 128, 'as_bit_string returns 1x128' );
 
         $ip = Net::Works::Address->new_from_integer(
             integer => $one,
             version => 4,
         );
 
-        is(
-            $ip->as_string(),
-            '0.0.0.1',
-            'as_string returns 0.0.0.1'
-        );
+        is( $ip->as_string(), '0.0.0.1', 'as_string returns 0.0.0.1' );
     };
 }
 
@@ -339,11 +233,8 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
             version => 6,
         );
 
-        is(
-            $ip->as_ipv4_string(),
-            $tests{$raw},
-            "$raw as IPv4 is $tests{$raw}"
-        );
+        is( $ip->as_ipv4_string(), $tests{$raw},
+            "$raw as IPv4 is $tests{$raw}" );
     }
 }
 
@@ -362,6 +253,7 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
 
 {
     {
+
         package Foo;
         use base qw(Net::Works::Address);
     }
@@ -369,18 +261,12 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
     my $ip = Foo->new_from_string( string => '1.2.3.4' );
 
     my $next = $ip->next_ip();
-    isa_ok(
-        $next,
-        'Foo',
-        'return object of child class for value of ->next_ip'
-    );
+    isa_ok( $next, 'Foo',
+        'return object of child class for value of ->next_ip' );
 
     my $prev = $ip->previous_ip();
-    isa_ok(
-        $prev,
-        'Foo',
-        'return object of child class for value of ->previous_ip'
-    );
+    isa_ok( $prev, 'Foo',
+        'return object of child class for value of ->previous_ip' );
 
     my %tests = (
         '::0'         => '0.0.0.0',
@@ -390,26 +276,14 @@ for my $one ( uint128(1), Math::BigInt->bone() ) {
     );
 
     for my $raw ( sort keys %tests ) {
-        my $ip = Foo->new_from_string(
+        my $foo = Foo->new_from_string(
             string  => $raw,
             version => 6,
         );
 
-        is(
-            $ip->as_ipv4_string(),
-            $tests{$raw},
-            "$raw as IPv4 is $tests{$raw}"
-        );
+        is( $foo->as_ipv4_string(),
+            $tests{$raw}, "$raw as IPv4 is $tests{$raw}" );
     }
-
-
-#    my $ipv4 = $ip->as_ipv4_string();
-#    isa_ok(
-#        $ipv4,
-#        'Foo',
-#        'return object of child class for value of ->as_ipv4_string'
-#    );
-
 }
 
 done_testing();


### PR DESCRIPTION
This adds in a change for the class returned by next_ip and previous_ip so that a child class object is returned when these subs are called.

This change was submitted as part of a cv-library pull request.